### PR TITLE
Fix: Translate Portuguese comments to English

### DIFF
--- a/src/DotTerritory/Territory.Bbox.cs
+++ b/src/DotTerritory/Territory.Bbox.cs
@@ -13,10 +13,10 @@ public static partial class Territory
             return default;
         }
 
-        // Iniciar com o bbox do primeiro feature
+        // Start with the bbox of the first feature
         var result = Bbox(features[0]);
 
-        // Combinar com os demais features
+        // Combine with the remaining features
         for (int i = 1; i < features.Count; i++)
         {
             result += Bbox(features[i]);


### PR DESCRIPTION
# Fix: Translate Portuguese comments to English

## Summary
Translates two Portuguese inline comments to English in `Territory.Bbox.cs` to maintain consistent English-only documentation throughout the codebase.

**Changes:**
- `"Iniciar com o bbox do primeiro feature"` → `"Start with the bbox of the first feature"`
- `"Combinar com os demais features"` → `"Combine with the remaining features"`

## Review & Testing Checklist for Human
- [ ] Verify the English translations accurately convey the original Portuguese meaning
- [ ] Confirm no functional code was accidentally modified (only comments changed)

### Notes
This change originated from a code review that identified inconsistent language usage in comments. The functionality remains completely unchanged.

**Link to Devin run:** https://app.devin.ai/sessions/74a3cdf1e8c44899bdd859c417acbaf5  
**Requested by:** Daniel Ferreira Monteiro Alves (@danfma)